### PR TITLE
fix: wire dependency graph into orchestrator to filter blocked tasks

### DIFF
--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -2,6 +2,8 @@ pub mod github;
 
 use serde::Serialize;
 
+use std::collections::HashSet;
+
 use crate::error::Result;
 
 /// Task priority (1 = highest, 9 = lowest).
@@ -55,6 +57,9 @@ pub trait TaskSource {
 
     /// Get full details for a task.
     fn get_task_details(&self, task_id: &str) -> Result<Task>;
+
+    /// Fetch IDs of closed/done tasks (used for dependency resolution).
+    fn fetch_closed_task_ids(&self) -> Result<HashSet<u64>>;
 }
 
 #[cfg(test)]

--- a/tests/orchestrator_integration.rs
+++ b/tests/orchestrator_integration.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::process::Command;
 use std::sync::{Arc, Mutex};
@@ -84,6 +84,10 @@ impl TaskSource for MockSource {
             .get(task_id)
             .cloned()
             .ok_or_else(|| Error::TaskSource(format!("task not found: {task_id}")))
+    }
+
+    fn fetch_closed_task_ids(&self) -> Result<HashSet<u64>> {
+        Ok(HashSet::new())
     }
 }
 


### PR DESCRIPTION
## Summary
- Wires the existing `deps.rs` dependency graph into the orchestrator's `run_once()` to pre-filter blocked tasks in Rust
- Adds `fetch_closed_task_ids()` to `TaskSource` trait, implemented in `GitHubSource` via `gh issue list --state closed`
- Fixes bug where the choose-phase agent incorrectly treated resolved blockers as still active (e.g. closed #6 still blocking #7)

## Test plan
- [x] All 137 existing tests pass
- [x] `cargo clippy` clean (no new warnings)
- [x] Manual verification: `cargo run -- --once` now correctly identifies #7 as unblocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)