### PR TITLE
Follow-up to #42: harden release dispatch and stdin error handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,11 @@ jobs:
         run: |
           set -euo pipefail
 
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" && "${GITHUB_REF}" != "refs/heads/main" ]]; then
+            echo "::error title=Invalid dispatch ref::Manual releases must run from main (got ${GITHUB_REF})"
+            exit 1
+          fi
+
           if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
             release_tag="${INPUT_TAG}"
           else


### PR DESCRIPTION
## Summary
- block manual workflow_dispatch releases unless run from main
- only ignore stdin write failures when they are BrokenPipe and the child exited non-zero
- add integration coverage for non-zero exit with broken pipe to prevent regressions

## Testing
- cargo fmt -- --check
- cargo test test_stdin_ -- --nocapture
- cargo test test_codex_nonzero_exit_detected -- --nocapture
- cargo test
