### PR TITLE
Fix .ralph → .rlph task.toml path typo

### DIFF
--- a/.rlph/docs/architecture.md
+++ b/.rlph/docs/architecture.md
@@ -6,7 +6,7 @@ The core loop in `orchestrator.rs` runs this sequence per iteration:
 
 ```
 Fetch tasks (TaskSource) → filter by dependency graph (deps.rs)
-  → Choose phase: agent picks task, writes .ralph/task.toml
+  → Choose phase: agent picks task, writes .rlph/task.toml
   → Create worktree (worktree.rs)
   → Implement phase: agent codes in worktree
   → Push branch, submit PR (SubmissionBackend)

--- a/src/default_prompts/choose-issue.md
+++ b/src/default_prompts/choose-issue.md
@@ -12,7 +12,7 @@ Do NOT implement the task yet.
      body: `blocked by #N`, `depends on #N`, `blockedBy: [N, M]`.
    - Prefer higher-priority issues (labels: `p1`-`p9`, `priority-high/medium/low`).
 3. Do not run external commands or tools for this phase.
-4. Save the chosen issue in `.ralph/task.toml` as a TOML object:
+4. Save the chosen issue in `.rlph/task.toml` as a TOML object:
 
 ```toml
 id = "gh-<issue number>"

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -461,7 +461,7 @@ impl<
             "choose phase complete"
         );
 
-        // 3. Parse task selection from .ralph/task.toml
+        // 3. Parse task selection from .rlph/task.toml
         let task_id = self.parse_task_selection()?;
         let issue_number = parse_issue_number(&task_id)?;
         info!(task_id, issue_number, "selected task");
@@ -977,9 +977,9 @@ impl<
         None
     }
 
-    /// Parse the task selection from `.ralph/task.toml` written by the choose agent.
+    /// Parse the task selection from `.rlph/task.toml` written by the choose agent.
     fn parse_task_selection(&self) -> Result<String> {
-        let path = self.repo_root.join(".ralph").join("task.toml");
+        let path = self.repo_root.join(".rlph").join("task.toml");
         let content = std::fs::read_to_string(&path).map_err(|e| {
             Error::Orchestrator(format!(
                 "failed to read task selection {}: {e}",

--- a/tests/orchestrator_integration.rs
+++ b/tests/orchestrator_integration.rs
@@ -105,7 +105,7 @@ impl AgentRunner for MockRunner {
     async fn run(&self, phase: Phase, _prompt: &str, working_dir: &Path) -> Result<RunResult> {
         match phase {
             Phase::Choose => {
-                let ralph_dir = working_dir.join(".ralph");
+                let ralph_dir = working_dir.join(".rlph");
                 std::fs::create_dir_all(&ralph_dir)
                     .map_err(|e| Error::AgentRunner(e.to_string()))?;
                 std::fs::write(
@@ -234,7 +234,7 @@ impl AgentRunner for CountingRunner {
         match phase {
             Phase::Choose => {
                 self.counts.choose.fetch_add(1, Ordering::SeqCst);
-                let ralph_dir = working_dir.join(".ralph");
+                let ralph_dir = working_dir.join(".rlph");
                 std::fs::create_dir_all(&ralph_dir)
                     .map_err(|e| Error::AgentRunner(e.to_string()))?;
                 std::fs::write(
@@ -299,7 +299,7 @@ impl AgentRunner for FailAtPhaseRunner {
         }
         match phase {
             Phase::Choose => {
-                let ralph_dir = working_dir.join(".ralph");
+                let ralph_dir = working_dir.join(".rlph");
                 std::fs::create_dir_all(&ralph_dir)
                     .map_err(|e| Error::AgentRunner(e.to_string()))?;
                 std::fs::write(
@@ -769,8 +769,8 @@ async fn test_full_loop_dry_run() {
     assert_eq!(state.history.len(), 1);
     assert_eq!(state.history[0].id, "gh-42");
 
-    // .ralph/task.toml should be cleaned up
-    assert!(!repo_dir.path().join(".ralph").join("task.toml").exists());
+    // .rlph/task.toml should be cleaned up
+    assert!(!repo_dir.path().join(".rlph").join("task.toml").exists());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- The choose agent prompt, orchestrator parser, and tests all referenced `.ralph/task.toml` instead of `.rlph/task.toml`
- This caused `rlph --once` to fail with "failed to read task selection" when a manually-created `.rlph/task.toml` existed
- Fixed all 4 files: `src/orchestrator.rs`, `src/default_prompts/choose-issue.md`, `tests/orchestrator_integration.rs`, `.rlph/docs/architecture.md`

## Test plan
- [x] `cargo test` — all 402 tests pass
- [x] `cargo clippy` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)