### PR TITLE
Auto-select single eligible task, skip choose phase

### DIFF
--- a/tests/orchestrator_integration.rs
+++ b/tests/orchestrator_integration.rs
@@ -864,7 +864,8 @@ async fn test_no_eligible_tasks() {
 #[tokio::test]
 async fn test_error_at_choose_phase() {
     let (_bare, repo_dir, wt_dir) = setup_git_repo();
-    let task = make_task(42, "Fix bug");
+    // Need 2+ tasks so choose phase actually runs (single task is auto-selected)
+    let tasks = vec![make_task(42, "Fix bug"), make_task(43, "Add feature")];
 
     let runner = FailAtPhaseRunner {
         fail_at: Phase::Choose,
@@ -875,7 +876,7 @@ async fn test_error_at_choose_phase() {
     let sub_tracker = Arc::new(Mutex::new(SubmissionTracker::default()));
 
     let orchestrator = Orchestrator::new(
-        MockSource::new(vec![task], Arc::clone(&source_tracker)),
+        MockSource::new(tasks, Arc::clone(&source_tracker)),
         runner,
         MockSubmission::new(Arc::clone(&sub_tracker), None),
         WorktreeManager::new(
@@ -1172,7 +1173,8 @@ async fn test_continuous_mode_polls_with_empty_results() {
 
     orchestrator.run_loop(None).await.unwrap();
 
-    assert_eq!(counts.choose.load(Ordering::SeqCst), 1);
+    // Single task → choose phase skipped (auto-selected)
+    assert_eq!(counts.choose.load(Ordering::SeqCst), 0);
     assert_eq!(counts.implement.load(Ordering::SeqCst), 1);
 }
 
@@ -1207,7 +1209,8 @@ async fn test_max_iterations_stops_at_limit() {
 
     orchestrator.run_loop(None).await.unwrap();
 
-    assert_eq!(counts.choose.load(Ordering::SeqCst), 3);
+    // Single task → choose phase skipped (auto-selected)
+    assert_eq!(counts.choose.load(Ordering::SeqCst), 0);
     assert_eq!(counts.implement.load(Ordering::SeqCst), 3);
 }
 
@@ -1246,7 +1249,8 @@ async fn test_continuous_shutdown_exits_between_iterations() {
 
     // Shutdown signal fires during implement, but the current iteration
     // completes fully. Shutdown is only checked between iterations.
-    assert_eq!(counts.choose.load(Ordering::SeqCst), 1);
+    // Single task → choose phase skipped (auto-selected)
+    assert_eq!(counts.choose.load(Ordering::SeqCst), 0);
     assert_eq!(counts.implement.load(Ordering::SeqCst), 1);
 }
 


### PR DESCRIPTION
## Summary
- When only 1 task is eligible, skip the choose agent phase entirely and auto-select it
- Avoids the `failed to read task selection .rlph/task.toml: No such file or directory` error when the choose agent doesn't create the file
- Saves an unnecessary agent invocation

## Test plan
- [x] `cargo clippy` — zero warnings
- [x] All 34 orchestrator integration tests pass
- [x] Updated 4 tests to reflect skipped choose phase with single task

🤖 Generated with [Claude Code](https://claude.com/claude-code)