### PR TITLE
Generate GitHub review comment from structured findings

### DIFF
--- a/src/default_prompts/review-aggregate-issue.md
+++ b/src/default_prompts/review-aggregate-issue.md
@@ -45,7 +45,7 @@ Respond with a single JSON object (no markdown fences, no commentary outside the
     }
   ],
   "verdict": "approved" | "needs_fix",
-  "comment": "<markdown PR comment — list issues as `- [ ] ...`>",
+  "comment": "<brief one-sentence summary of the review outcome>",
   "fix_instructions": "<concise fix instructions, or null if approved>"
 }
 ```

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -13,7 +13,7 @@ use crate::error::{Error, Result};
 use crate::prompts::PromptEngine;
 use crate::review_schema::{
     SchemaName, Verdict, correction_prompt, parse_aggregator_output, parse_fix_output,
-    parse_phase_output, render_findings_for_prompt,
+    parse_phase_output, render_findings_for_github, render_findings_for_prompt,
 };
 use crate::runner::{
     AgentRunner, AnyRunner, Phase, RunResult, RunnerKind, build_runner, resume_with_correction,
@@ -834,7 +834,10 @@ impl<
                 }
             };
 
-            let comment_body = format!("{REVIEW_MARKER}\n{}", agg_output.comment);
+            let comment_body = format!(
+                "{REVIEW_MARKER}\n{}",
+                render_findings_for_github(&agg_output.findings, &agg_output.comment),
+            );
             let summary = agg_output.comment.trim();
             if !summary.is_empty() {
                 self.reporter.review_summary(summary);

--- a/tests/prompt_rendering.rs
+++ b/tests/prompt_rendering.rs
@@ -493,7 +493,7 @@ Respond with a single JSON object (no markdown fences, no commentary outside the
     }
   ],
   \"verdict\": \"approved\" | \"needs_fix\",
-  \"comment\": \"<markdown PR comment — list issues as `- [ ] ...`>\",
+  \"comment\": \"<brief one-sentence summary of the review outcome>\",
   \"fix_instructions\": \"<concise fix instructions, or null if approved>\"
 }
 ```


### PR DESCRIPTION
Build the PR comment body programmatically via render_findings_for_github()
instead of using the aggregator LLM's free-form comment verbatim. Findings
are grouped by category with severity-sorted checklist items.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
