### PR TITLE
Increase default implement phase timeout to 30 minutes

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -67,6 +67,10 @@ pub struct Cli {
     #[arg(long)]
     pub agent_timeout: Option<u64>,
 
+    /// Implement phase timeout in seconds (default: 1800)
+    #[arg(long)]
+    pub implement_timeout: Option<u64>,
+
     /// Effort level for the agent (low, medium, high) — Claude/Codex runner only
     #[arg(long)]
     pub agent_effort: Option<String>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -91,6 +91,7 @@ pub struct ConfigFile {
     pub agent_binary: Option<String>,
     pub agent_model: Option<String>,
     pub agent_timeout: Option<u64>,
+    pub implement_timeout: Option<u64>,
     pub agent_effort: Option<String>,
     pub agent_variant: Option<String>,
     pub max_review_rounds: Option<u32>,
@@ -117,6 +118,7 @@ pub struct Config {
     pub agent_binary: String,
     pub agent_model: Option<String>,
     pub agent_timeout: Option<u64>,
+    pub implement_timeout: Option<u64>,
     pub agent_effort: Option<String>,
     pub agent_variant: Option<String>,
     pub max_review_rounds: u32,
@@ -321,6 +323,10 @@ pub fn merge(file: ConfigFile, cli: &Cli) -> Result<Config> {
         .or_else(|| default_effort.map(str::to_string));
     let global_variant = global_variant_override.clone();
     let global_timeout = cli.agent_timeout.or(file.agent_timeout).or(Some(600));
+    let implement_timeout = cli
+        .implement_timeout
+        .or(file.implement_timeout)
+        .or(Some(1800));
 
     let review_phases: Vec<ReviewPhaseConfig> = file
         .review_phases
@@ -438,6 +444,7 @@ pub fn merge(file: ConfigFile, cli: &Cli) -> Result<Config> {
         agent_binary: global_binary,
         agent_model: global_model,
         agent_timeout: global_timeout,
+        implement_timeout,
         agent_effort: global_effort,
         agent_variant: global_variant,
         max_review_rounds: cli
@@ -697,6 +704,7 @@ worktree_dir = "/tmp/wt"
         assert_eq!(config.agent_model.as_deref(), Some("claude-opus-4-6"));
         assert_eq!(config.agent_effort.as_deref(), Some("high"));
         assert_eq!(config.agent_timeout, Some(600));
+        assert_eq!(config.implement_timeout, Some(1800));
         assert_eq!(config.agent_timeout_retries, 2);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,7 +158,7 @@ async fn main() {
 
             let state_mgr = StateManager::new(StateManager::default_dir(&repo_root));
             let prompt_engine = PromptEngine::new(None);
-            let timeout = config.agent_timeout.map(Duration::from_secs);
+            let timeout = config.implement_timeout.map(Duration::from_secs);
             let factory = rlph::orchestrator::DefaultReviewRunnerFactory { stream: true };
             let orchestrator = Orchestrator::new(
                 source,
@@ -307,7 +307,7 @@ async fn main() {
         },
         _ => AnySource::GitHub(GitHubSource::new(&config)),
     };
-    let timeout = config.agent_timeout.map(Duration::from_secs);
+    let timeout = config.implement_timeout.map(Duration::from_secs);
     let runner = build_runner(
         config.runner,
         &config.agent_binary,

--- a/src/prd.rs
+++ b/src/prd.rs
@@ -220,6 +220,7 @@ mod tests {
             agent_binary: binary.to_string(),
             agent_model: model.map(str::to_string),
             agent_timeout: Some(600),
+            implement_timeout: Some(1800),
             agent_effort: Some("high".to_string()),
             agent_variant: None,
             max_review_rounds: 3,

--- a/tests/orchestrator_integration.rs
+++ b/tests/orchestrator_integration.rs
@@ -671,6 +671,7 @@ fn make_config(dry_run: bool) -> Config {
         agent_binary: "claude".to_string(),
         agent_model: None,
         agent_timeout: None,
+        implement_timeout: None,
         agent_effort: None,
         agent_variant: None,
         max_review_rounds: 3,

--- a/tests/prd_integration.rs
+++ b/tests/prd_integration.rs
@@ -21,6 +21,7 @@ fn test_config(source: &str) -> Config {
         agent_binary: "claude".to_string(),
         agent_model: Some("claude-opus-4-6".to_string()),
         agent_timeout: Some(600),
+        implement_timeout: Some(1800),
         agent_effort: Some("high".to_string()),
         agent_variant: None,
         max_review_rounds: 3,


### PR DESCRIPTION
## Summary
- Add separate `implement_timeout` config field (default 1800s / 30 min) for the implement phase, decoupled from the global `agent_timeout` (600s) used by review phases
- Configurable via `--implement-timeout <SECONDS>` CLI flag or `implement_timeout` in config TOML

## Test plan
- [x] `cargo clippy` — zero warnings
- [x] `cargo nextest run -E 'test(test_defaults)' -E 'test(test_agent_timeout)'` — passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)