### PR TITLE
Fix pre-commit hook for worktrees

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -1,3 +1,4 @@
 #!/bin/sh
-cargo fmt
-git add -u
+# Setup: ln -sf ../../.hooks/pre-commit .git/hooks/pre-commit
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings


### PR DESCRIPTION
## Summary
- Remove `core.hooksPath` config override that broke in worktrees (relative path resolved wrong)
- Use symlink `.git/hooks/pre-commit → ../../.hooks/pre-commit` so Git's default worktree hook resolution works
- Upgrade hook to check-only `cargo fmt --check` + `cargo clippy` instead of auto-formatting and staging

## Setup (new clones)
```sh
ln -sf ../../.hooks/pre-commit .git/hooks/pre-commit
```

## Test plan
- [ ] `git commit --allow-empty -m "test"` in main repo → hook runs
- [ ] Create worktree, commit in it → hook runs
- [ ] Verify `git config --local --get core.hooksPath` returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)