### PR TITLE
Add eyes reaction to fix flow for in-progress signaling

### DIFF
--- a/src/fix.rs
+++ b/src/fix.rs
@@ -18,8 +18,8 @@ const MAX_CONCURRENT_FIXES: usize = 1;
 use crate::config::{Config, ReviewStepConfig};
 use crate::error::{Error, Result};
 use crate::fix_comment::{
-    FindingState, FixItem, FixResultKind, REACTION_CONFUSED, REACTION_THUMBS_UP, ReplyMap,
-    build_fix_items_from_review_comments, collect_reply_bodies, format_review_context,
+    FindingState, FixItem, FixResultKind, REACTION_CONFUSED, REACTION_EYES, REACTION_THUMBS_UP,
+    ReplyMap, build_fix_items_from_review_comments, collect_reply_bodies, format_review_context,
 };
 use crate::fix_deps::{FindingDeps, resolved_finding_ids};
 use crate::orchestrator::{CorrectionRunner, retry_with_correction};
@@ -723,6 +723,22 @@ async fn run_fix_agent_and_apply(
     submission: &(impl SubmissionBackend + ?Sized),
     correction_runner: &(impl CorrectionRunner + ?Sized),
 ) -> Result<()> {
+    // Add 👀 reaction to signal "working on it" (best-effort)
+    let eyes_reaction_id =
+        match submission.add_review_comment_reaction(ctx.item.comment_id, REACTION_EYES) {
+            Ok(id) if id > 0 => Some(id),
+            Ok(_) => None,
+            Err(e) => {
+                warn!(
+                    finding_id = %ctx.item.finding.id,
+                    comment_id = ctx.item.comment_id,
+                    error = %e,
+                    "failed to add 👀 reaction"
+                );
+                None
+            }
+        };
+
     // Spawn fix agent
     info!(finding_id = %ctx.item.finding.id, "spawning fix agent");
     let runner = build_runner(
@@ -763,7 +779,7 @@ async fn run_fix_agent_and_apply(
     };
 
     // Update reactions and post reply (best-effort — don't fail on already-pushed code)
-    update_reactions_and_reply(ctx, submission, &fix_result);
+    update_reactions_and_reply(ctx, submission, &fix_result, eyes_reaction_id);
 
     Ok(())
 }
@@ -816,13 +832,15 @@ fn cleanup_stale_rockets(items: &[FixItem], submission: &(impl SubmissionBackend
 /// - Add 👍 (fixed) or 😕 (won't fix)
 /// - Post a reply with details
 /// - Remove all 🚀 reactions
+/// - Remove 👀 reaction if present
 ///
-/// The outcome emoji and reply are added before removing 🚀 so that observers
+/// The outcome emoji and reply are added before removing 🚀/👀 so that observers
 /// always see the result before the queuing signal disappears.
 fn update_reactions_and_reply(
     ctx: &FixContext<'_>,
     submission: &(impl SubmissionBackend + ?Sized),
     fix_result: &FixResultKind,
+    eyes_reaction_id: Option<u64>,
 ) {
     let comment_id = ctx.item.comment_id;
     let finding_id = &ctx.item.finding.id;
@@ -866,6 +884,17 @@ fn update_reactions_and_reply(
         &ctx.item.rocket_reaction_ids,
         submission,
     );
+
+    // Remove 👀 reaction (best-effort)
+    if let Some(reaction_id) = eyes_reaction_id
+        && let Err(e) = submission.delete_review_comment_reaction(comment_id, reaction_id)
+    {
+        warn!(
+            %finding_id, comment_id, reaction_id,
+            error = %e,
+            "failed to remove 👀 reaction"
+        );
+    }
 }
 
 /// Parse fix output with up to 2 retries via session resume.

--- a/src/fix_comment.rs
+++ b/src/fix_comment.rs
@@ -15,6 +15,7 @@ pub type ReplyMap = HashMap<u64, Vec<String>>;
 pub const REACTION_ROCKET: &str = "rocket";
 pub const REACTION_THUMBS_UP: &str = "+1";
 pub const REACTION_CONFUSED: &str = "confused";
+pub const REACTION_EYES: &str = "eyes";
 
 /// State of a finding derived from reactions on its inline review comment.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -1156,8 +1156,8 @@ mod tests {
             Ok(vec![])
         }
 
-        fn add_review_comment_reaction(&self, _comment_id: u64, _reaction: &str) -> Result<()> {
-            Ok(())
+        fn add_review_comment_reaction(&self, _comment_id: u64, _reaction: &str) -> Result<u64> {
+            Ok(0)
         }
 
         fn delete_review_comment_reaction(

--- a/src/submission.rs
+++ b/src/submission.rs
@@ -138,8 +138,10 @@ pub trait SubmissionBackend: Send + Sync {
 
     /// Add a reaction to a PR review comment. `reaction` is one of:
     /// "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes".
-    fn add_review_comment_reaction(&self, _comment_id: u64, _reaction: &str) -> Result<()> {
-        Ok(())
+    ///
+    /// Returns the ID of the created reaction.
+    fn add_review_comment_reaction(&self, _comment_id: u64, _reaction: &str) -> Result<u64> {
+        Ok(0)
     }
 
     /// Remove a reaction from a PR review comment by reaction ID.
@@ -560,11 +562,16 @@ impl SubmissionBackend for GitHubSubmission {
         ))
     }
 
-    fn add_review_comment_reaction(&self, comment_id: u64, reaction: &str) -> Result<()> {
+    fn add_review_comment_reaction(&self, comment_id: u64, reaction: &str) -> Result<u64> {
         let endpoint = format!("repos/{{owner}}/{{repo}}/pulls/comments/{comment_id}/reactions");
-        run_gh_api_mutate(&endpoint, "POST", &[("content", reaction)])?;
-        info!(comment_id, reaction, "added reaction to review comment");
-        Ok(())
+        let response =
+            run_gh_api_mutate_with_response(&endpoint, "POST", &[("content", reaction)])?;
+        let id: u64 = serde_json::from_str::<serde_json::Value>(&response)
+            .ok()
+            .and_then(|v| v.get("id")?.as_u64())
+            .unwrap_or(0);
+        info!(comment_id, reaction, id, "added reaction to review comment");
+        Ok(id)
     }
 
     fn delete_review_comment_reaction(&self, comment_id: u64, reaction_id: u64) -> Result<()> {
@@ -699,6 +706,28 @@ pub(crate) fn run_gh_api_paginated<T: DeserializeOwned>(endpoint: &str) -> Resul
     let stdout = String::from_utf8_lossy(&output.stdout);
     serde_json::from_str(&stdout)
         .map_err(|e| Error::Submission(format!("failed to parse gh api response: {e}")))
+}
+
+fn run_gh_api_mutate_with_response(
+    endpoint: &str,
+    method: &str,
+    fields: &[(&str, &str)],
+) -> Result<String> {
+    let mut cmd = Command::new("gh");
+    cmd.args(["api", endpoint, "-X", method]);
+    for (key, value) in fields {
+        cmd.args(["-f", &format!("{key}={value}")]);
+    }
+    let output = cmd
+        .output()
+        .map_err(|e| Error::Submission(format!("failed to run gh: {e}")))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(Error::Submission(format!(
+            "gh api {endpoint} failed: {stderr}"
+        )));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
 }
 
 fn run_gh_api_mutate(endpoint: &str, method: &str, fields: &[(&str, &str)]) -> Result<()> {

--- a/tests/fix_integration.rs
+++ b/tests/fix_integration.rs
@@ -141,7 +141,7 @@ impl SubmissionBackend for MockFixSubmission {
             .unwrap_or_default())
     }
 
-    fn add_review_comment_reaction(&self, comment_id: u64, reaction: &str) -> Result<()> {
+    fn add_review_comment_reaction(&self, comment_id: u64, reaction: &str) -> Result<u64> {
         let new_id = self.next_reaction_id.fetch_add(1, Ordering::SeqCst);
         self.added_reactions
             .lock()
@@ -165,7 +165,7 @@ impl SubmissionBackend for MockFixSubmission {
                 }],
             ));
         }
-        Ok(())
+        Ok(new_id)
     }
 
     fn delete_review_comment_reaction(&self, comment_id: u64, reaction_id: u64) -> Result<()> {
@@ -286,23 +286,25 @@ async fn test_parallel_fix_multiple_queued_items() {
 
     assert!(result.is_ok(), "run_fix failed: {:?}", result.err());
 
-    // Each fix should have: removed 🚀, added 👍, posted reply
+    // Each fix should have: added 👀 + 👍, removed 🚀 + 👀, posted reply
     assert_eq!(
         submission.deleted_reaction_count(),
-        3,
-        "expected 3 🚀 reactions removed"
+        6,
+        "expected 6 reactions removed (3 🚀 + 3 👀)"
     );
     assert_eq!(
         submission.added_reaction_count(),
-        3,
-        "expected 3 result reactions added"
+        6,
+        "expected 6 reactions added (3 👀 + 3 👍)"
     );
     assert_eq!(submission.reply_count(), 3, "expected 3 replies posted");
 
-    // All added reactions should be "+1" (fixed)
-    for (_, reaction) in submission.added_reactions() {
-        assert_eq!(reaction, "+1");
-    }
+    // Should have 3 "eyes" and 3 "+1" reactions added
+    let added = submission.added_reactions();
+    let eyes_count = added.iter().filter(|(_, r)| r == "eyes").count();
+    let thumbs_count = added.iter().filter(|(_, r)| r == "+1").count();
+    assert_eq!(eyes_count, 3, "expected 3 👀 reactions added");
+    assert_eq!(thumbs_count, 3, "expected 3 👍 reactions added");
 }
 
 /// Test that `run_fix` with no 🚀-reacted items returns Ok and does nothing.
@@ -483,7 +485,7 @@ impl SubmissionBackend for PollingMockSubmission {
         self.base.list_review_comment_reactions(comment_id)
     }
 
-    fn add_review_comment_reaction(&self, comment_id: u64, reaction: &str) -> Result<()> {
+    fn add_review_comment_reaction(&self, comment_id: u64, reaction: &str) -> Result<u64> {
         self.base.add_review_comment_reaction(comment_id, reaction)
     }
 


### PR DESCRIPTION
## Summary
When `rlph fix` picks up a queued finding, there's no visual signal that it's actively being worked on — observers only see the 🚀 (queued) and then the final 👍/😕 (done). Adding a 👀 reaction when work begins and removing it on completion gives a clear "in progress" indicator, closing the observability gap between "queued" and "resolved".

- Adds 👀 reaction before spawning the fix agent (best-effort)
- Removes it after the result reaction and reply are posted
- Changes `add_review_comment_reaction` return type to `Result<u64>` so the reaction ID can be tracked for removal

Flow: `🚀 (queued) → 👀 added (working on it) → agent runs → 👍/😕 added → reply posted → 🚀 removed → 👀 removed`

## Test plan
- [x] `cargo clippy` — zero warnings
- [x] `cargo nextest run` — all 551 tests pass
- [x] Integration test verifies 👀 reactions are both added and removed via mock assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)