### PR TITLE
Move build loop under `rlph build` subcommand

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,6 +20,22 @@ pub struct Cli {
     pub config: Option<String>,
 }
 
+/// Agent identity args shared by Build and Prd subcommands.
+#[derive(Args, Debug, Clone, Default)]
+pub struct AgentArgs {
+    /// Agent runner to use (claude, codex, opencode)
+    #[arg(long)]
+    pub runner: Option<String>,
+
+    /// Agent binary to use (default: claude)
+    #[arg(long)]
+    pub agent_binary: Option<String>,
+
+    /// Model for the agent to use (default for claude: claude-opus-4-6)
+    #[arg(long)]
+    pub agent_model: Option<String>,
+}
+
 #[derive(Args, Debug, Clone, Default)]
 pub struct BuildArgs {
     /// Run a single iteration then exit
@@ -38,9 +54,8 @@ pub struct BuildArgs {
     #[arg(long)]
     pub dry_run: bool,
 
-    /// Agent runner to use (claude, codex, opencode)
-    #[arg(long)]
-    pub runner: Option<String>,
+    #[command(flatten)]
+    pub agent: AgentArgs,
 
     /// Submission backend to use (github, graphite)
     #[arg(long)]
@@ -57,14 +72,6 @@ pub struct BuildArgs {
     /// Base branch for worktrees and PRs (default: main)
     #[arg(long)]
     pub base_branch: Option<String>,
-
-    /// Agent binary to use (default: claude)
-    #[arg(long)]
-    pub agent_binary: Option<String>,
-
-    /// Model for the agent to use (default for claude: claude-opus-4-6)
-    #[arg(long)]
-    pub agent_model: Option<String>,
 
     /// Agent timeout in seconds
     #[arg(long)]
@@ -91,6 +98,14 @@ impl Cli {
     pub fn build_args(&self) -> Option<&BuildArgs> {
         match &self.command {
             CliCommand::Build { args } => Some(args),
+            _ => None,
+        }
+    }
+
+    pub fn agent_args(&self) -> Option<&AgentArgs> {
+        match &self.command {
+            CliCommand::Build { args } => Some(&args.agent),
+            CliCommand::Prd { agent, .. } => Some(agent),
             _ => None,
         }
     }
@@ -128,17 +143,8 @@ pub enum CliCommand {
         /// Seed description for the PRD (optional)
         description: Option<String>,
 
-        /// Agent runner to use (claude, codex)
-        #[arg(long)]
-        runner: Option<String>,
-
-        /// Agent binary to use
-        #[arg(long)]
-        agent_binary: Option<String>,
-
-        /// Model for the agent to use
-        #[arg(long)]
-        agent_model: Option<String>,
+        #[command(flatten)]
+        agent: AgentArgs,
     },
 }
 
@@ -204,7 +210,7 @@ mod tests {
         ]);
         match cli.command {
             CliCommand::Build { args } => {
-                assert_eq!(args.runner.as_deref(), Some("codex"));
+                assert_eq!(args.agent.runner.as_deref(), Some("codex"));
                 assert_eq!(args.submission.as_deref(), Some("graphite"));
                 assert_eq!(args.poll_seconds, Some(30));
                 assert_eq!(args.worktree_dir.as_deref(), Some("/tmp/wt"));
@@ -301,11 +307,10 @@ mod tests {
         match cli.command {
             CliCommand::Prd {
                 description,
-                runner,
-                ..
+                ref agent,
             } => {
                 assert_eq!(description.as_deref(), Some("my feature"));
-                assert_eq!(runner.as_deref(), Some("codex"));
+                assert_eq!(agent.runner.as_deref(), Some("codex"));
             }
             _ => panic!("expected Prd subcommand"),
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -281,8 +281,9 @@ fn runner_default_effort(runner: RunnerKind) -> Option<&'static str> {
 }
 
 pub fn merge(file: ConfigFile, cli: &Cli, build: Option<&BuildArgs>) -> Result<Config> {
-    let runner: RunnerKind = build
-        .and_then(|b| b.runner.as_deref())
+    let agent = cli.agent_args();
+    let runner: RunnerKind = agent
+        .and_then(|a| a.runner.as_deref())
         .or(file.runner.as_deref())
         .unwrap_or("claude")
         .parse()?;
@@ -306,8 +307,8 @@ pub fn merge(file: ConfigFile, cli: &Cli, build: Option<&BuildArgs>) -> Result<C
         done_state: lc.done_state.unwrap_or_else(|| "Done".to_string()),
     });
 
-    let build_binary = build.and_then(|b| b.agent_binary.clone());
-    let build_model = build.and_then(|b| b.agent_model.clone());
+    let build_binary = agent.and_then(|a| a.agent_binary.clone());
+    let build_model = agent.and_then(|a| a.agent_model.clone());
     let build_effort = build.and_then(|b| b.agent_effort.clone());
     let build_variant = build.and_then(|b| b.agent_variant.clone());
     let global_binary_override = build_binary.or(file.agent_binary);

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use tokio::sync::watch;
 use tracing::{debug, info};
 use tracing_subscriber::EnvFilter;
 
-use rlph::cli::{BuildArgs, Cli, CliCommand};
+use rlph::cli::{Cli, CliCommand};
 use rlph::config::{Config, resolve_init_config};
 use rlph::fix;
 use rlph::fix_comment::format_fix_items_for_display;
@@ -306,19 +306,9 @@ async fn main() {
             }
         }
         CliCommand::Prd {
-            ref description,
-            ref runner,
-            ref agent_binary,
-            ref agent_model,
+            ref description, ..
         } => {
-            let prd_build = BuildArgs {
-                runner: runner.clone(),
-                agent_binary: agent_binary.clone(),
-                agent_model: agent_model.clone(),
-                ..Default::default()
-            };
-
-            let cfg = match Config::load(&cli, Some(&prd_build)) {
+            let cfg = match Config::load(&cli, None) {
                 Ok(c) => c,
                 Err(e) => {
                     eprintln!("error: {e}");


### PR DESCRIPTION
## Summary

- Moves the build loop (fetch tasks → spin up worktrees → run agents) from bare `rlph` into an explicit `rlph build` subcommand
- Bare `rlph` now prints help instead of requiring `--once`/`--continuous`
- Extracts all build-specific CLI flags into a `BuildArgs` struct, keeping only global flags (`--source`, `--label`, `--config`) on the top-level `Cli`

## Details

**`src/cli.rs`**
- New `BuildArgs` struct (derives `Args`, `Default`) with 16 build-specific flags
- `Build { args: BuildArgs }` variant added to `CliCommand` using `#[command(flatten)]`
- `Cli.command` changed from `Option<CliCommand>` → `CliCommand` with `subcommand_required = true`
- `Cli::build_args()` helper to extract `Option<&BuildArgs>` from command variant

**`src/config.rs`**
- `Config::load` / `load_from` / `merge` now accept `Option<&BuildArgs>`
- Build-specific fields read from `BuildArgs` when present, falling back to config file defaults
- ~50 tests updated from `["rlph", "--once", ...]` → `["rlph", "build", "--once", ...]`

**`src/main.rs`**
- Build loop moved into `CliCommand::Build` match arm
- `Review` / `Fix` pass `None` for build args (config-file only for runner/agent settings)
- `Prd` constructs a `BuildArgs` from its own overrides instead of cloning+mutating `Cli`

## Migration

```diff
- rlph --once
+ rlph build --once

- rlph --continuous --max-iterations 5
+ rlph build --continuous --max-iterations 5

- rlph --once --runner codex --dry-run
+ rlph build --once --runner codex --dry-run
```

`rlph init`, `rlph review`, `rlph fix`, `rlph prd` are unchanged.

## Test plan

- [x] `cargo clippy` — zero warnings
- [x] `cargo nextest run` — all 550 tests pass
- [ ] Manual: `rlph` prints help
- [ ] Manual: `rlph build --once` runs single iteration

🤖 Generated with [Claude Code](https://claude.com/claude-code)