### PR TITLE
Change default Codex model to gpt-5.4

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -269,7 +269,7 @@ fn runner_default_binary(runner: RunnerKind) -> &'static str {
 
 fn runner_default_model(runner: RunnerKind) -> Option<&'static str> {
     match runner {
-        RunnerKind::Codex => Some("gpt-5.3-codex"),
+        RunnerKind::Codex => Some("gpt-5.4"),
         RunnerKind::Claude => Some("claude-opus-4-6"),
         RunnerKind::OpenCode => None,
     }
@@ -868,7 +868,7 @@ worktree_dir = "/tmp/wt"
         let cli = Cli::parse_from(["rlph", "build", "--once", "--runner", "codex"]);
         let config = Config::load_from(&cli, cli.build_args(), tmp.path()).unwrap();
         assert_eq!(config.agent_binary, "codex");
-        assert_eq!(config.agent_model.as_deref(), Some("gpt-5.3-codex"));
+        assert_eq!(config.agent_model.as_deref(), Some("gpt-5.4"));
     }
 
     #[test]

--- a/src/prd.rs
+++ b/src/prd.rs
@@ -193,7 +193,7 @@ mod tests {
 
     #[test]
     fn test_build_prd_command_codex_same_behavior() {
-        let config = test_config_codex("codex", "github", Some("gpt-5.3-codex"));
+        let config = test_config_codex("codex", "github", Some("gpt-5.4"));
         let (cmd, args) = build_prd_command(&config, "rendered prompt", Some("add auth"));
         assert_eq!(cmd, "codex");
         let positional = args.last().unwrap();
@@ -201,7 +201,7 @@ mod tests {
         assert!(positional.contains("## Desired Objective"));
         assert!(positional.contains("add auth"));
         assert!(args.contains(&"--model".to_string()));
-        assert!(args.contains(&"gpt-5.3-codex".to_string()));
+        assert!(args.contains(&"gpt-5.4".to_string()));
     }
 
     fn test_config(binary: &str, source: &str, model: Option<&str>) -> Config {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1395,7 +1395,7 @@ mod tests {
         let runner = build_runner(
             RunnerKind::Codex,
             "codex",
-            Some("gpt-5.3"),
+            Some("gpt-5.4"),
             None,
             None,
             None,
@@ -1463,14 +1463,14 @@ mod tests {
     fn test_codex_build_resume_command_with_model() {
         let runner = CodexRunner::new(
             "codex".to_string(),
-            Some("gpt-5.3".to_string()),
+            Some("gpt-5.4".to_string()),
             None,
             None,
             2,
         );
         let (_cmd, args) = runner.build_resume_command();
         assert!(args.contains(&"--model".to_string()));
-        assert!(args.contains(&"gpt-5.3".to_string()));
+        assert!(args.contains(&"gpt-5.4".to_string()));
         assert!(args.contains(&"resume".to_string()));
         assert!(args.contains(&"--last".to_string()));
     }
@@ -1648,12 +1648,12 @@ mod tests {
     fn test_codex_resume_with_prompt_command_with_model_and_effort() {
         let (_cmd, args) = build_codex_resume_with_prompt_command(
             "codex",
-            Some("gpt-5.3"),
+            Some("gpt-5.4"),
             Some("medium"),
             "thread-xyz",
         );
         assert!(args.contains(&"--model".to_string()));
-        assert!(args.contains(&"gpt-5.3".to_string()));
+        assert!(args.contains(&"gpt-5.4".to_string()));
         assert!(args.contains(&"--config".to_string()));
         assert!(args.contains(&"model_reasoning_effort=\"medium\"".to_string()));
         assert!(args.contains(&"resume".to_string()));

--- a/tests/codex_binary.rs
+++ b/tests/codex_binary.rs
@@ -148,7 +148,7 @@ async fn test_codex_model_flag() {
     let mut args = base_args();
     args.extend([
         "--model".to_string(),
-        "gpt-5.3-codex".to_string(),
+        "gpt-5.4".to_string(),
         "-".to_string(),
     ]);
 

--- a/tests/prd_integration.rs
+++ b/tests/prd_integration.rs
@@ -37,7 +37,7 @@ fn test_config_codex(source: &str) -> Config {
     Config {
         runner: RunnerKind::Codex,
         agent_binary: "codex".to_string(),
-        agent_model: Some("gpt-5.3-codex".to_string()),
+        agent_model: Some("gpt-5.4".to_string()),
         ..test_config(source)
     }
 }
@@ -133,7 +133,7 @@ fn test_prd_command_codex_includes_model() {
     let config = test_config_codex("github");
     let (_, args) = build_prd_command(&config, "prompt", None);
     assert!(args.contains(&"--model".to_string()));
-    assert!(args.contains(&"gpt-5.3-codex".to_string()));
+    assert!(args.contains(&"gpt-5.4".to_string()));
 }
 
 /// End-to-end: mock agent binary verifies template is passed as positional arg.


### PR DESCRIPTION
## Summary
- change the default Codex runner model from `gpt-5.3-codex` to `gpt-5.4`
- update Codex-specific fixtures and pass-through tests to match the new default

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run`
- `cargo nextest run --profile integration -E 'binary(cli_binary)'`
- `cargo nextest run --profile integration --no-fail-fast` *(fails in external runner binary suites: `claude_binary`, `codex_binary`, and `opencode_binary`; `cli_binary` passes in full)*